### PR TITLE
Adds options hash to get_user method

### DIFF
--- a/lib/angellist_api/client/users.rb
+++ b/lib/angellist_api/client/users.rb
@@ -11,9 +11,9 @@ module AngellistApi
       # @param [Integer] id ID of the desired user.
       #
       # @example Get a user's information given an id.
-      #   AngellistApi.get_user(1234)
-      def get_user(id)
-        get("1/users/#{id}")
+      #   AngellistApi.get_user(1234, :include_details => 'investor')
+      def get_user(id, options={})
+        get("1/users/#{id}", options)
       end
 
       # Get information for a batch of up to 50 users given a list of user IDs.


### PR DESCRIPTION
Allows :include_details => 'investor' to pull investor details such as startups_per_year, average_amount, accreditation, markets, locations, investments.
